### PR TITLE
Use XmlStreamReader to determine encoding of XML stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
 
 
     <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-nop -->
         <dependency>

--- a/src/main/java/com/github/oowekyala/ooxml/messages/SpyInputSource.java
+++ b/src/main/java/com/github/oowekyala/ooxml/messages/SpyInputSource.java
@@ -31,10 +31,11 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.function.Supplier;
 
+import org.apache.commons.io.input.XmlStreamReader;
 import org.xml.sax.InputSource;
 
 class SpyInputSource extends InputSource {
@@ -54,15 +55,15 @@ class SpyInputSource extends InputSource {
         if (byteStream == null) {
             return;
         }
-        InputStreamReader reader;
-        if (getEncoding() != null) {
-            try {
+        Reader reader;
+        try {
+            if (getEncoding() != null) {
                 reader = new InputStreamReader(byteStream, getEncoding());
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
+            } else {
+                reader = new XmlStreamReader(byteStream);
             }
-        } else {
-            reader = new InputStreamReader(byteStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
 
         setCharacterStream(reader);

--- a/src/test/kotlin/com/github/oowekyala/ooxml/messages/EncodingTest.kt
+++ b/src/test/kotlin/com/github/oowekyala/ooxml/messages/EncodingTest.kt
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Andreas Dangel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.oowekyala.ooxml.messages
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import org.xml.sax.InputSource
+import java.io.InputStream
+import java.nio.charset.Charset
+import javax.xml.parsers.DocumentBuilder
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.assertEquals
+
+class EncodingTest : IntelliMarker, FunSpec({
+
+
+    fun domBuilder(): DocumentBuilder =
+            DocumentBuilderFactory.newInstance().newDocumentBuilder()
+
+    fun InputStream.parseStr(handler: TestMessagePrinter): PositionedXmlDoc =
+            OoxmlFacade()
+                .withPrinter(handler).parse(domBuilder(), InputSource(this))
+
+    test("Test InputStream with encoding") {
+        // make sure, the current platform encoding is UTF-8.
+        // it must not be ISO-8859-1 - that's what the test file is using.
+        assertEquals("UTF-8", Charset.defaultCharset().name())
+
+        val printer = TestMessagePrinter()
+
+        val stream  = EncodingTest::class.java.getResourceAsStream("latin1.xml")
+
+        val doc = stream.parseStr(printer)
+        assertEquals("ISO-8859-1", doc.document.xmlEncoding)
+        assertEquals("With Umlauts: ä", doc.document.getElementsByTagName("message").item(0).textContent)
+        printer.err.shouldBeEmpty()
+    }
+
+})

--- a/src/test/resources/com/github/oowekyala/ooxml/messages/latin1.xml
+++ b/src/test/resources/com/github/oowekyala/ooxml/messages/latin1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<sample>
+    <message>With Umlauts: ä</message>
+</sample>


### PR DESCRIPTION
Without this, the library uses the platform default encoding instead of the encoding specified in the XML file.